### PR TITLE
Change systemd PrivateTmp to false

### DIFF
--- a/caddy/templates/caddy.service
+++ b/caddy/templates/caddy.service
@@ -9,7 +9,7 @@ Group={{ user }}
 ExecStart=/usr/local/bin/caddy run --environ --config {{ config_file }} {% if enable_api %}--resume{% endif %}
 ExecReload=/usr/local/bin/caddy reload --config {{ config_file }}
 TimeoutStopSec=5s
-PrivateTmp=true
+PrivateTmp=false
 ProtectSystem=full
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 


### PR DESCRIPTION
Do not create a private `/tmp` directory for the caddy service process. Doing so has been interfering with the locking mechanism employed by a webhook script that we run. A manual invocation of the script does not have access to the lock directory that we put in the `/tmp` directory.
